### PR TITLE
Remove discord app default background color

### DIFF
--- a/src/theme/app/_background.scss
+++ b/src/theme/app/_background.scss
@@ -129,3 +129,8 @@
 		}
 	}
 }
+
+// Remove discord app default background color (potentially if user want to use --background-image: transparent;)
+.app__160d8, .appMount__51fd7, body {
+    background: transparent;
+}


### PR DESCRIPTION
Remove the default gray background of discord app. Potentially if user wants to use transparent background.